### PR TITLE
Make detailed and of return 6 weeks

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,7 +155,7 @@ function calendar(config) {
       cbData
     ) {
       var calendar = [];
-      var totalWeeks = Math.ceil((numberOfDays + firstWeekday) / 7);
+      var totalWeeks = 6;
       var totalDaysOnWeek = 7;
       var lastWeek = totalWeeks - 1;
       var execCb = typeof dayTransformer === 'function';


### PR DESCRIPTION
This makes `detailed` and `of` return exactly 6 weeks.  It makes using this library in a date-picker more predictable and much easier.